### PR TITLE
refactor: avoid logging full database url

### DIFF
--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -4,8 +4,13 @@ const postgres = require("postgres");
 
 const runMigration = async () => {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
-
-  console.log(process.env.DATABASE_URL);
+  // Log only non-sensitive connection details for debugging purposes
+  try {
+    const { host } = new URL(process.env.DATABASE_URL);
+    console.log(`Running migration against host: ${host}`);
+  } catch {
+    // Swallow errors parsing the URL to avoid exposing secrets
+  }
 
   const sql = postgres(process.env.DATABASE_URL, { max: 1 });
   const db = drizzle(sql);


### PR DESCRIPTION
## Summary
- avoid logging entire `DATABASE_URL` in migrations; log host only - Let's keep things secure!

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76e0d337483248887bf2f8b2c3001