### PR TITLE
fix: use specialty as key in AdvocateTable

### DIFF
--- a/src/components/advocates/AdvocateTable.tsx
+++ b/src/components/advocates/AdvocateTable.tsx
@@ -32,9 +32,9 @@ export function AdvocateTable({ advocates, onPhoneClick }: AdvocateTableProps) {
               <td className="px-6 py-4 text-gray-700 align-top w-1/12">{advocate.degree}</td>
               <td className="px-6 py-4 align-top w-1/3">
                 <div className="flex flex-wrap gap-1">
-                  {advocate.specialties.map((specialty, i) => (
+                  {advocate.specialties.map((specialty) => (
                     <span
-                      key={i}
+                      key={specialty}
                       className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
                     >
                       {specialty}


### PR DESCRIPTION
## Summary
- replace index-based React keys for specialties with specialty strings to avoid key collisions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b77365d5948324b3529fc02391f47b