### PR TITLE
Use native tel links for advocate contact

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
 import { SearchBar, AdvocateResults } from "../components/advocates";
 import { Banner } from "../components/ui";
-import { cleanPhoneNumber } from "../lib/utils";
 
 export default function Home() {
   const {
@@ -15,12 +14,6 @@ export default function Home() {
     handleSearchChange,
     resetSearch
   } = useDebouncedSearch(300);
-
-  // Helper function to handle phone number click
-  const handlePhoneClick = (phoneNumber: string) => {
-    const cleanNumber = cleanPhoneNumber(phoneNumber);
-    window.location.href = `tel:${cleanNumber}`;
-  };
 
   return (
     <div className="min-h-screen bg-white">
@@ -42,12 +35,11 @@ export default function Home() {
             onReset={resetSearch}
           />
 
-          <AdvocateResults 
+          <AdvocateResults
             advocates={advocates}
             pagination={pagination}
             loading={loading}
             error={error}
-            onPhoneClick={handlePhoneClick}
           />
         </div>
       </section>

--- a/src/components/advocates/AdvocateResults.tsx
+++ b/src/components/advocates/AdvocateResults.tsx
@@ -9,15 +9,13 @@ interface AdvocateResultsProps {
   pagination: PaginationInfoType | null;
   loading: boolean;
   error: string | null;
-  onPhoneClick: (phoneNumber: string) => void;
 }
 
-export function AdvocateResults({ 
-  advocates, 
-  pagination, 
-  loading, 
-  error, 
-  onPhoneClick 
+export function AdvocateResults({
+  advocates,
+  pagination,
+  loading,
+  error
 }: AdvocateResultsProps) {
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
@@ -31,7 +29,7 @@ export function AdvocateResults({
         <LoadingSpinner />
       ) : (
         <>
-          <AdvocateTable advocates={advocates} onPhoneClick={onPhoneClick} />
+          <AdvocateTable advocates={advocates} />
           
           {advocates.length === 0 && !loading && (
             <div className="px-6 py-12 text-center text-gray-500">

--- a/src/components/advocates/AdvocateTable.tsx
+++ b/src/components/advocates/AdvocateTable.tsx
@@ -1,12 +1,11 @@
 import { Advocate } from "../../types/advocate.types";
-import { formatPhoneNumber } from "../../lib/utils";
+import { formatPhoneNumber, cleanPhoneNumber } from "../../lib/utils";
 
 interface AdvocateTableProps {
   advocates: Advocate[];
-  onPhoneClick: (phoneNumber: string) => void;
 }
 
-export function AdvocateTable({ advocates, onPhoneClick }: AdvocateTableProps) {
+export function AdvocateTable({ advocates }: AdvocateTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
@@ -46,13 +45,12 @@ export function AdvocateTable({ advocates, onPhoneClick }: AdvocateTableProps) {
                 {advocate.yearsOfExperience} years
               </td>
               <td className="px-6 py-4 align-top w-1/4">
-                <button 
-                  onClick={() => onPhoneClick(advocate.phoneNumber)}
+                <a
+                  href={`tel:${cleanPhoneNumber(advocate.phoneNumber)}`}
                   className="text-green-700 hover:text-green-800 font-medium hover:underline transition-colors"
-                  title="Click to call"
                 >
                   {formatPhoneNumber(advocate.phoneNumber)}
-                </button>
+                </a>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- remove client-side phone click handler and rely on native `tel:` links
- simplify Advocate components by dropping `onPhoneClick` prop
- format `tel:` links using existing `cleanPhoneNumber`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7738b35548324a57b322a901c1b5e