### PR TITLE
Add testing framework and basic tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({
+  dir: './',
+});
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "generate": "drizzle-kit generate",
     "migrate:up": "node ./src/db/migrate.js",
-    "seed": "tsx ./src/db/seed/index.ts"
+    "seed": "tsx ./src/db/seed/index.ts",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^17.2.2",
@@ -30,6 +31,12 @@
     "postcss": "^8.4.40",
     "tailwindcss": "^3.4.7",
     "tsx": "^4.19.2",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.3",
+    "@testing-library/user-event": "^14.5.4",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/app/api/advocates/route.test.ts
+++ b/src/app/api/advocates/route.test.ts
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+import { GET } from './route';
+
+const mockData = [
+  {
+    id: 1,
+    firstName: 'John',
+    lastName: 'Doe',
+    city: 'NYC',
+    degree: 'MD',
+    specialties: ['Cardiology'],
+    yearsOfExperience: 5,
+    phoneNumber: '1234567890',
+  },
+  {
+    id: 2,
+    firstName: 'Jane',
+    lastName: 'Smith',
+    city: 'LA',
+    degree: 'PhD',
+    specialties: ['Oncology'],
+    yearsOfExperience: 10,
+    phoneNumber: '0987654321',
+  },
+];
+
+const mockCountResult = [{ count: mockData.length }];
+
+const mockOffset = jest.fn().mockResolvedValue(mockData);
+const mockLimit = jest.fn(() => ({ offset: mockOffset }));
+export const mockWhereData = jest.fn(() => ({ limit: mockLimit }));
+const mockFromData = jest.fn(() => ({ where: mockWhereData, limit: mockLimit }));
+const mockWhereCount = jest.fn().mockResolvedValue(mockCountResult);
+const mockFromCount = jest.fn(() => {
+  const result: any = Promise.resolve(mockCountResult);
+  result.where = mockWhereCount;
+  return result;
+});
+const mockSelect = jest.fn((arg?: any) => {
+  if (arg && arg.count) {
+    return { from: mockFromCount };
+  }
+  return { from: mockFromData };
+});
+
+jest.mock('../../../db', () => ({
+  __esModule: true,
+  default: { select: mockSelect },
+}));
+
+describe('GET /api/advocates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DATABASE_URL = 'postgres://test';
+  });
+
+  it('returns paginated results', async () => {
+    const request = new Request('http://localhost/api/advocates?page=1&limit=2');
+    const response = await GET(request);
+    const body = await response.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.pagination).toEqual({
+      page: 1,
+      limit: 2,
+      total: 2,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
+    expect(mockWhereData).not.toHaveBeenCalled();
+  });
+
+  it('applies search filter', async () => {
+    const request = new Request('http://localhost/api/advocates?search=John&page=1&limit=20');
+    const response = await GET(request);
+    const body = await response.json();
+    expect(mockWhereData).toHaveBeenCalled();
+    expect(body.data).toEqual(mockData);
+  });
+});

--- a/src/components/advocates/__tests__/AdvocateTable.test.tsx
+++ b/src/components/advocates/__tests__/AdvocateTable.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AdvocateTable } from '../AdvocateTable';
+import type { Advocate } from '../../../types/advocate.types';
+
+describe('AdvocateTable', () => {
+  const advocates: Advocate[] = [
+    {
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      city: 'NYC',
+      degree: 'MD',
+      specialties: ['Cardiology'],
+      yearsOfExperience: 5,
+      phoneNumber: '1234567890',
+    },
+  ];
+
+  it('renders advocate data and handles phone click', async () => {
+    const user = userEvent.setup();
+    const onPhoneClick = jest.fn();
+    render(<AdvocateTable advocates={advocates} onPhoneClick={onPhoneClick} />);
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('NYC')).toBeInTheDocument();
+    expect(screen.getByText('MD')).toBeInTheDocument();
+    expect(screen.getByText('Cardiology')).toBeInTheDocument();
+    expect(screen.getByText('5 years')).toBeInTheDocument();
+    const phone = screen.getByText('(123) 456-7890');
+    expect(phone).toBeInTheDocument();
+
+    await user.click(phone);
+    expect(onPhoneClick).toHaveBeenCalledWith('1234567890');
+  });
+});

--- a/src/components/advocates/__tests__/SearchBar.test.tsx
+++ b/src/components/advocates/__tests__/SearchBar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SearchBar } from '../SearchBar';
+
+describe('SearchBar', () => {
+  it('sanitizes input and calls onSearchChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    const handleReset = jest.fn();
+
+    const { rerender } = render(
+      <SearchBar searchTerm="" onSearchChange={handleChange} onReset={handleReset} />
+    );
+
+    const input = screen.getByPlaceholderText(/search by name/i);
+    await user.type(input, '<John>');
+
+    expect(handleChange).toHaveBeenLastCalledWith('John');
+
+    // simulate parent updating searchTerm
+    rerender(
+      <SearchBar searchTerm="John" onSearchChange={handleChange} onReset={handleReset} />
+    );
+    expect(screen.getByText(/Searching for:/)).toHaveTextContent('John');
+
+    await user.click(screen.getByText(/Reset Search/i));
+    expect(handleReset).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with React Testing Library
- add API, SearchBar, and AdvocateTable tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77390311483248caaa70e0b856b42