### PR TITLE
Technical interview updates

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     volumes:
       - psql:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - 5433:5432
 volumes:
   psql:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,15 +12,13 @@ export default function Home() {
     loading,
     error,
     handleSearchChange,
-    resetSearch
+    resetSearch,
   } = useDebouncedSearch(300);
 
   return (
     <div className="min-h-screen bg-white">
       {/* Top Banner */}
-      <Banner>
-        Healthcare Advocate Directory
-      </Banner>
+      <Banner>Healthcare Advocate Directory</Banner>
 
       {/* Search Section */}
       <section className="bg-gray-50 py-12 px-6">
@@ -28,8 +26,8 @@ export default function Home() {
           <h2 className="text-3xl font-serif text-gray-900 mb-8 text-center">
             Find Your Healthcare Advocate
           </h2>
-          
-          <SearchBar 
+
+          <SearchBar
             searchTerm={searchTerm}
             onSearchChange={handleSearchChange}
             onReset={resetSearch}
@@ -37,6 +35,7 @@ export default function Home() {
 
           <AdvocateResults
             advocates={advocates}
+            search={searchTerm}
             pagination={pagination}
             loading={loading}
             error={error}

--- a/src/components/advocates/AdvocateResults.tsx
+++ b/src/components/advocates/AdvocateResults.tsx
@@ -6,6 +6,7 @@ import { PaginationInfo } from "./PaginationInfo";
 
 interface AdvocateResultsProps {
   advocates: Advocate[];
+  search: string;
   pagination: PaginationInfoType | null;
   loading: boolean;
   error: string | null;
@@ -13,9 +14,10 @@ interface AdvocateResultsProps {
 
 export function AdvocateResults({
   advocates,
+  search,
   pagination,
   loading,
-  error
+  error,
 }: AdvocateResultsProps) {
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
@@ -24,22 +26,20 @@ export function AdvocateResults({
           <p>Error: {error}</p>
         </div>
       )}
-      
+
       {loading ? (
         <LoadingSpinner />
       ) : (
         <>
-          <AdvocateTable advocates={advocates} />
-          
+          <AdvocateTable advocates={advocates} search={search} />
+
           {advocates.length === 0 && !loading && (
             <div className="px-6 py-12 text-center text-gray-500">
               <p>No advocates found matching your search criteria.</p>
             </div>
           )}
 
-          {pagination && (
-            <PaginationInfo pagination={pagination} />
-          )}
+          {pagination && <PaginationInfo pagination={pagination} />}
         </>
       )}
     </div>

--- a/src/components/advocates/AdvocateTable.tsx
+++ b/src/components/advocates/AdvocateTable.tsx
@@ -1,12 +1,12 @@
 import { Advocate } from "../../types/advocate.types";
 import { formatPhoneNumber, cleanPhoneNumber } from "../../lib/utils";
-import { highlightText } from "@/utils/highlightText";
 
 interface AdvocateTableProps {
   advocates: Advocate[];
+  search: string;
 }
 
-export function AdvocateTable({ advocates }: AdvocateTableProps) {
+export function AdvocateTable({ advocates, search }: AdvocateTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
@@ -39,35 +39,35 @@ export function AdvocateTable({ advocates }: AdvocateTableProps) {
               className="hover:bg-gray-50 transition-colors">
               <td className="px-6 py-4 align-top w-1/6">
                 <div className="font-medium text-gray-900">
-                  {highlight(advocate.firstName, "John")}{" "}
-                  {highlight(advocate.lastName, "Doe")}
+                  {highlight(advocate.firstName, search)}{" "}
+                  {highlight(advocate.lastName, search)}
                 </div>
               </td>
               <td className="px-6 py-4 text-gray-700 align-top w-1/6">
-                {advocate.city}
+                {highlight(advocate.city, search)}
               </td>
               <td className="px-6 py-4 text-gray-700 align-top w-1/12">
-                {advocate.degree}
+                {highlight(advocate.degree, search)}
               </td>
               <td className="px-6 py-4 align-top w-1/3">
                 <div className="flex flex-wrap gap-1">
                   {advocate.specialties.map((specialty) => (
                     <span
                       key={specialty}
-                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      {specialty}
+                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-mediu bg-green-100 text-green-800">
+                      {highlight(specialty, search)}
                     </span>
                   ))}
                 </div>
               </td>
               <td className="px-6 py-4 text-gray-700 align-top w-1/12">
-                {advocate.yearsOfExperience} years
+                {highlight(advocate.yearsOfExperience.toString(), search)} years
               </td>
               <td className="px-6 py-4 align-top w-1/4">
                 <a
                   href={`tel:${cleanPhoneNumber(advocate.phoneNumber)}`}
                   className="text-green-700 hover:text-green-800 font-medium hover:underline transition-colors">
-                  {formatPhoneNumber(advocate.phoneNumber)}
+                  {highlight(formatPhoneNumber(advocate.phoneNumber), search)}
                 </a>
               </td>
             </tr>
@@ -78,12 +78,23 @@ export function AdvocateTable({ advocates }: AdvocateTableProps) {
   );
 }
 
-const highlight = (text: string, search: string) =>
-  highlightText(text, search)
-    .split("")
-    .map((char) => {
-      if (char === "[") {
-        return <span className="bg-green-100 text-green-800">{search}</span>;
-      }
-      return char;
-    });
+const highlight = (text: string, search: string) => {
+  if (!search || !text) {
+    return text;
+  }
+  const parts = text.split(search);
+  return (
+    <>
+      {parts.map((part, index) => (
+        <span key={index}>
+          {part}
+          {index < parts.length - 1 && (
+            <span className="bg-pink-100 text-black-900 border border-black rounded-md px-1 margin-0 padding-0">
+              {search}
+            </span>
+          )}
+        </span>
+      ))}
+    </>
+  );
+};

--- a/src/components/advocates/AdvocateTable.tsx
+++ b/src/components/advocates/AdvocateTable.tsx
@@ -1,5 +1,6 @@
 import { Advocate } from "../../types/advocate.types";
 import { formatPhoneNumber, cleanPhoneNumber } from "../../lib/utils";
+import { highlightText } from "@/utils/highlightText";
 
 interface AdvocateTableProps {
   advocates: Advocate[];
@@ -11,31 +12,49 @@ export function AdvocateTable({ advocates }: AdvocateTableProps) {
       <table className="w-full">
         <thead className="bg-gray-50">
           <tr>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/6">Name</th>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/6">City</th>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/12">Degree</th>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/3">Specialties</th>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/12">Experience</th>
-            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/4">Contact</th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/6">
+              Name
+            </th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/6">
+              City
+            </th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/12">
+              Degree
+            </th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/3">
+              Specialties
+            </th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/12">
+              Experience
+            </th>
+            <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 w-1/4">
+              Contact
+            </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200">
           {advocates.map((advocate: Advocate) => (
-            <tr key={advocate.id} className="hover:bg-gray-50 transition-colors">
+            <tr
+              key={advocate.id}
+              className="hover:bg-gray-50 transition-colors">
               <td className="px-6 py-4 align-top w-1/6">
                 <div className="font-medium text-gray-900">
-                  {advocate.firstName} {advocate.lastName}
+                  {highlight(advocate.firstName, "John")}{" "}
+                  {highlight(advocate.lastName, "Doe")}
                 </div>
               </td>
-              <td className="px-6 py-4 text-gray-700 align-top w-1/6">{advocate.city}</td>
-              <td className="px-6 py-4 text-gray-700 align-top w-1/12">{advocate.degree}</td>
+              <td className="px-6 py-4 text-gray-700 align-top w-1/6">
+                {advocate.city}
+              </td>
+              <td className="px-6 py-4 text-gray-700 align-top w-1/12">
+                {advocate.degree}
+              </td>
               <td className="px-6 py-4 align-top w-1/3">
                 <div className="flex flex-wrap gap-1">
                   {advocate.specialties.map((specialty) => (
                     <span
                       key={specialty}
-                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
-                    >
+                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
                       {specialty}
                     </span>
                   ))}
@@ -47,8 +66,7 @@ export function AdvocateTable({ advocates }: AdvocateTableProps) {
               <td className="px-6 py-4 align-top w-1/4">
                 <a
                   href={`tel:${cleanPhoneNumber(advocate.phoneNumber)}`}
-                  className="text-green-700 hover:text-green-800 font-medium hover:underline transition-colors"
-                >
+                  className="text-green-700 hover:text-green-800 font-medium hover:underline transition-colors">
                   {formatPhoneNumber(advocate.phoneNumber)}
                 </a>
               </td>
@@ -59,3 +77,13 @@ export function AdvocateTable({ advocates }: AdvocateTableProps) {
     </div>
   );
 }
+
+const highlight = (text: string, search: string) =>
+  highlightText(text, search)
+    .split("")
+    .map((char) => {
+      if (char === "[") {
+        return <span className="bg-green-100 text-green-800">{search}</span>;
+      }
+      return char;
+    });

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -4,7 +4,6 @@ import {
   PaginationInfo,
   SearchResponse,
 } from "../types/advocate.types";
-import { highlightText } from "../utils/highlightText";
 
 export function useDebouncedSearch(debounceMs: number = 300) {
   const [searchTerm, setSearchTerm] = useState("");

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -1,9 +1,14 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Advocate, PaginationInfo, SearchResponse } from '../types/advocate.types';
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Advocate,
+  PaginationInfo,
+  SearchResponse,
+} from "../types/advocate.types";
+import { highlightText } from "../utils/highlightText";
 
 export function useDebouncedSearch(debounceMs: number = 300) {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
   const [data, setData] = useState<Advocate[]>([]);
   const [pagination, setPagination] = useState<PaginationInfo | null>(null);
   const [loading, setLoading] = useState(false);
@@ -25,41 +30,42 @@ export function useDebouncedSearch(debounceMs: number = 300) {
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
-    if (process.env.NODE_ENV === 'development') {
-      console.log('Fetching data:', { search, page });
+    if (process.env.NODE_ENV === "development") {
+      console.log("Fetching data:", { search, page });
     }
     setLoading(true);
     setError(null);
-    
+
     try {
       const params = new URLSearchParams({
         search: search,
         page: page.toString(),
-        limit: '20'
+        limit: "20",
       });
-      
+
       const response = await fetch(`/api/advocates?${params}`, {
-        signal: controller.signal
+        signal: controller.signal,
       });
-      
+
       if (!response.ok) {
-        throw new Error('Failed to fetch advocates');
+        throw new Error("Failed to fetch advocates");
       }
-      
+
       const result: SearchResponse = await response.json();
-      if (process.env.NODE_ENV === 'development') {
-        console.log('Received data:', result);
+      if (process.env.NODE_ENV === "development") {
+        console.log("Received data:", result);
       }
+
       setData(result.data);
       setPagination(result.pagination);
     } catch (err) {
-      if ((err as any).name === 'AbortError') {
-        if (process.env.NODE_ENV === 'development') {
-          console.log('Request aborted');
+      if ((err as any).name === "AbortError") {
+        if (process.env.NODE_ENV === "development") {
+          console.log("Request aborted");
         }
       } else {
-        console.error('Error fetching data:', err);
-        setError(err instanceof Error ? err.message : 'An error occurred');
+        console.error("Error fetching data:", err);
+        setError(err instanceof Error ? err.message : "An error occurred");
         setData([]);
         setPagination(null);
       }
@@ -71,18 +77,18 @@ export function useDebouncedSearch(debounceMs: number = 300) {
   // Initial data fetch on component mount
   useEffect(() => {
     if (!initialLoadRef.current) {
-      if (process.env.NODE_ENV === 'development') {
-        console.log('Initial data fetch');
+      if (process.env.NODE_ENV === "development") {
+        console.log("Initial data fetch");
       }
-      fetchData('');
+      fetchData("");
       initialLoadRef.current = true;
     }
   }, [fetchData]);
 
   useEffect(() => {
     if (initialLoadRef.current) {
-      if (process.env.NODE_ENV === 'development') {
-        console.log('Search term changed:', debouncedSearchTerm);
+      if (process.env.NODE_ENV === "development") {
+        console.log("Search term changed:", debouncedSearchTerm);
       }
       fetchData(debouncedSearchTerm);
     }
@@ -97,8 +103,8 @@ export function useDebouncedSearch(debounceMs: number = 300) {
   };
 
   const resetSearch = () => {
-    setSearchTerm('');
-    setDebouncedSearchTerm('');
+    setSearchTerm("");
+    setDebouncedSearchTerm("");
   };
 
   return {
@@ -109,6 +115,6 @@ export function useDebouncedSearch(debounceMs: number = 300) {
     error,
     handleSearchChange,
     handlePageChange,
-    resetSearch
+    resetSearch,
   };
 }

--- a/src/utils/highlightText.ts
+++ b/src/utils/highlightText.ts
@@ -1,0 +1,3 @@
+export function highlightText(text: string, search: string) {
+  return text.replaceAll(search, `[`);
+}

--- a/src/utils/highlightText.ts
+++ b/src/utils/highlightText.ts
@@ -1,3 +1,0 @@
-export function highlightText(text: string, search: string) {
-  return text.replaceAll(search, `[`);
-}


### PR DESCRIPTION
Here is a PR with the updates from today's interview.  There are two commits.  

The [first commit](https://github.com/jongrantwritescode/solace-engineering-assignment/commit/eab468b9790b471bfaddb0fdd28aede893d003dc) is what we got done in the interview.

- Highlighting of predefined serach terms for first name ("John") and last name ("Doe"). 
- No other highlighting

The first approach was adding the highlight spans in the search hook using a util - but that resulted in the HTML elements printed to the screen.  Tried a few ways to get the string to insert HTML for rendering.  In the end, we replaced the search term with '[' as a placeholder value, split the string on (""), and replaced "[" with the html span surrounding the search term.

The [scond commit ](https://github.com/jongrantwritescode/solace-engineering-assignment/commit/30ac5df6df92d941750df3c773cbcad14de6fde0)completes the technical part of the feature, but isn't super pretty.

- The search term is prop drilled down into the table
- The highlighting util is removed in favor of local processing in the table
- Highlighting method checks for text and search, then returns a span with the text and the search term highlighted via span

The biggest hurdle was getting something to show up for the specialities since they already had a green BG.  The UI adds a border and highlight - but it adds weird spacing in the text string.  Follow up would be getting the UX to look better.  I did have the method working with an array .map, but did have AI clean it up and it wrapped everything in the empty fragment.

**First Name Search**
<img width="1229" height="662" alt="Screenshot 2025-09-09 at 12 26 47 PM" src="https://github.com/user-attachments/assets/5d94d70b-6ea4-4765-98ec-6c39842c44c3" />

**Speciality Search**
<img width="1267" height="551" alt="Screenshot 2025-09-09 at 12 26 38 PM" src="https://github.com/user-attachments/assets/7a911828-886d-4465-95e8-bbd576ecc424" />
